### PR TITLE
travis: PHP 5.6, 7.0 nightly added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ language: php
 php:
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
+
+matrix:
+  allow_failures:
+    - php: 7.0
 
 before_script:
   - composer selfupdate


### PR DESCRIPTION
To be compatible with version in `composer.json`.

Can do for other repos if accepted.