### PR TITLE
Handling domain events recorded in listeners

### DIFF
--- a/src/Recorder/HandlesRecordedMessagesMiddleware.php
+++ b/src/Recorder/HandlesRecordedMessagesMiddleware.php
@@ -41,5 +41,9 @@ class HandlesRecordedMessagesMiddleware implements MessageBusMiddleware
         foreach ($recordedMessages as $recordedMessage) {
             $this->messageBus->handle($recordedMessage);
         }
+
+        if ($this->messageRecorder->recordedMessages()) {
+            $this->handle($message, $next);
+        }
     }
 }


### PR DESCRIPTION
This makes sure messages created in listeners for other messages are handled to.

A use case:
1. *Entity1* is updated using the `command_bus`. This causes *Entity1* to record a domain message.
2. The `HandlesRecordedMessagesMiddleware` handles the message and calls the registered listener.
3. The listener updates *Entity2*, which causes it record another domain message.
4. The domain message created by *Entity2* is not handled.

If this functionality was already in place, and I simply missed it, please let me know, and I'll close this PR :)