### PR TITLE
Added Logging for SubscriberNotififierMiddleware

### DIFF
--- a/src/Subscriber/NotifiesMessageSubscribersMiddleware.php
+++ b/src/Subscriber/NotifiesMessageSubscribersMiddleware.php
@@ -2,6 +2,9 @@
 
 namespace SimpleBus\Message\Subscriber;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
 use SimpleBus\Message\Bus\Middleware\MessageBusMiddleware;
 use SimpleBus\Message\Subscriber\Resolver\MessageSubscribersResolver;
 
@@ -12,9 +15,26 @@ class NotifiesMessageSubscribersMiddleware implements MessageBusMiddleware
      */
     private $messageSubscribersResolver;
 
-    public function __construct(MessageSubscribersResolver $messageSubscribersResolver)
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var string
+     */
+    private $level;
+
+    public function __construct(MessageSubscribersResolver $messageSubscribersResolver, LoggerInterface $logger = null, $level = LogLevel::DEBUG)
     {
         $this->messageSubscribersResolver = $messageSubscribersResolver;
+
+        if (null === $logger) {
+            $logger = new NullLogger;
+        }
+
+        $this->logger = $logger;
+        $this->level = $level;
     }
 
     public function handle($message, callable $next)
@@ -22,7 +42,11 @@ class NotifiesMessageSubscribersMiddleware implements MessageBusMiddleware
         $messageSubscribers = $this->messageSubscribersResolver->resolve($message);
 
         foreach ($messageSubscribers as $messageSubscriber) {
+            $this->logger->log($this->level, 'Started notifying a subscriber', ['subscriber' => $messageSubscriber]);
+
             call_user_func($messageSubscriber, $message);
+
+            $this->logger->log($this->level, 'Finished notifying a subscriber', ['subscriber' => $messageSubscriber]);
         }
 
         $next($message);

--- a/tests/Subscriber/NotifiesMessageSubscribersMiddlewareTest.php
+++ b/tests/Subscriber/NotifiesMessageSubscribersMiddlewareTest.php
@@ -2,6 +2,7 @@
 
 namespace SimpleBus\Message\Tests\Subscriber;
 
+use Psr\Log\LogLevel;
 use SimpleBus\Message\Subscriber\NotifiesMessageSubscribersMiddleware;
 use SimpleBus\Message\Subscriber\Resolver\MessageSubscribersResolver;
 use SimpleBus\Message\Tests\Fixtures\CallableSpy;
@@ -25,6 +26,52 @@ class NotifiesMessageSubscribersMiddlewareTest extends \PHPUnit_Framework_TestCa
 
         $resolver = $this->mockMessageSubscribersResolver($message, $messageSubscribers);
         $middleware = new NotifiesMessageSubscribersMiddleware($resolver);
+
+        $next = new CallableSpy();
+
+        $middleware->handle($message, $next);
+
+        $this->assertSame([$message], $next->receivedMessages());
+        $this->assertSame([$message], $messageSubscriber1->receivedMessages());
+        $this->assertSame([$message], $messageSubscriber2->receivedMessages());
+    }
+
+    /**
+     * @test
+     */
+    public function it_logs_every_call_to_a_subscriber()
+    {
+        $message = $this->dummyMessage();
+
+        $messageSubscriber1 = new CallableSpy();
+        $messageSubscriber2 = new CallableSpy();
+
+        $messageSubscribers = [
+            $messageSubscriber1,
+            $messageSubscriber2
+        ];
+
+        $resolver = $this->mockMessageSubscribersResolver($message, $messageSubscribers);
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $level = LogLevel::CRITICAL;
+
+        $middleware = new NotifiesMessageSubscribersMiddleware($resolver, $logger, $level);
+
+        $logger->expects($this->at(0))
+            ->method('log')
+            ->with($level, 'Started notifying a subscriber');
+
+        $logger->expects($this->at(1))
+            ->method('log')
+            ->with($level, 'Finished notifying a subscriber');
+
+        $logger->expects($this->at(2))
+            ->method('log')
+            ->with($level, 'Started notifying a subscriber');
+
+        $logger->expects($this->at(3))
+            ->method('log')
+            ->with($level, 'Finished notifying a subscriber');
 
         $next = new CallableSpy();
 


### PR DESCRIPTION
Currently, there is no way to know which Subscribers have been called. 

This pull request adds support for logging inside a copy of `NotifiesMessageSubscribersMiddleware`.


To enable this you'll need to add the following to `event_bus_logging.yml`:
```yaml
    simple_bus.event_bus.notifies_message_subscribers_middleware:
        class: SimpleBus\Message\Logging\LoggingNotifiesMessageSubscribersMiddleware
        public: false
        arguments:
            - @simple_bus.event_bus.event_subscribers_resolver
            - @logger
            - %simple_bus.event_bus.logging.level%
        tags:
            - { name: event_bus_middleware, priority: -1000 }
```