### PR TITLE
Extend example of $eventSubscribersByEventName

### DIFF
--- a/doc/event_bus.md
+++ b/doc/event_bus.md
@@ -44,17 +44,12 @@ use SimpleBus\Message\CallableResolver\ServiceLocatorAwareCallableResolver;
 
 // Provide a map of event names to callables. You can provide actual callables, or lazy-loading ones using a ServiceLocator
 $eventSubscribersByEventName = [
-<<<<<<< HEAD
     Fully\Qualified\Class\Name\Of\Event::class => [
         $fqcn = My\Class\Name::class, // Will use ServiceLocator for instantiation and invoke $instance->notify() if that function exists on the $instance
         $object = new My\Class\Name(), // Will not use ServiceLocator and invoke $object->notify()
         $callable1 = [My\Class\Name::class, 'notify'], // Will not use ServiceLocator and invoke My\Class\Name::notify() statically
         $callable2 = [new My\Class\Name(), 'notify'], // Will not use ServiceLocator and invoke $serviceInstance->notify()
         $callable3 = ['event_subscriber_service_id', 'notify'], // Will use ServiceLocator to instantiate service and invoke '$object->notify()' method
-=======
-    'Fully\Qualified\Class\Name\Of\Event' => [
-        ['event_subscriber_service_id', 'notify'],
->>>>>>> SimpleBus/master
         ['another_event_subscriber_service_id', 'notify']
     ]
 ];

--- a/doc/event_bus.md
+++ b/doc/event_bus.md
@@ -45,11 +45,11 @@ use SimpleBus\Message\CallableResolver\ServiceLocatorAwareCallableResolver;
 // Provide a map of event names to callables. You can provide actual callables, or lazy-loading ones using a ServiceLocator
 $eventSubscribersByEventName = [
     Fully\Qualified\Class\Name\Of\Event::class => [
-        $fqcn = My\Class\Name::class, //Will use ServiceLocator for instantiation and invoke $instance->notify()
-        $object = new My\Class\Name(), //Will not use ServiceLocator and invoke $object->notify()
-        $callable1 = [My\Class\Name::class, 'notify'], //Will not use ServiceLocator and invoke My\Class\Name::notify() statically
-        $callable2 = [new My\Class\Name(), 'notify'], //Will not use ServiceLocator and invoke $serviceInstance->notify()
-        $callable3 = ['event_subscriber_service_id', 'notify'], //Will use ServiceLocator to instantiate service and invoke '$object->notify()' method
+        $fqcn = My\Class\Name::class, // Will use ServiceLocator for instantiation and invoke $instance->notify() if that function exists on the $instance
+        $object = new My\Class\Name(), // Will not use ServiceLocator and invoke $object->notify()
+        $callable1 = [My\Class\Name::class, 'notify'], // Will not use ServiceLocator and invoke My\Class\Name::notify() statically
+        $callable2 = [new My\Class\Name(), 'notify'], // Will not use ServiceLocator and invoke $serviceInstance->notify()
+        $callable3 = ['event_subscriber_service_id', 'notify'], // Will use ServiceLocator to instantiate service and invoke '$object->notify()' method
         ['another_event_subscriber_service_id', 'notify']
     ]
 ];

--- a/doc/event_bus.md
+++ b/doc/event_bus.md
@@ -42,10 +42,14 @@ every event subscriber will be fully loaded, even though it is not going to be u
 use SimpleBus\Message\CallableResolver\CallableCollection;
 use SimpleBus\Message\CallableResolver\ServiceLocatorAwareCallableResolver;
 
-// Provide a map of event names to callables. You can provide actual callables, or lazy-loading ones.
+// Provide a map of event names to callables. You can provide actual callables, or lazy-loading ones using a ServiceLocator
 $eventSubscribersByEventName = [
-    'Fully\Qualified\Class\Name\Of\Event' => [
-        ['event_subscriber_service_id', 'notify']
+    Fully\Qualified\Class\Name\Of\Event::class => [
+        $fqcn = My\Class\Name::class, //Will use ServiceLocator for instantiation and invoke $instance->notify()
+        $object = new My\Class\Name(), //Will not use ServiceLocator and invoke $object->notify()
+        $callable1 = [My\Class\Name::class, 'notify'], //Will not use ServiceLocator and invoke My\Class\Name::notify() statically
+        $callable2 = [new My\Class\Name(), 'notify'], //Will not use ServiceLocator and invoke $serviceInstance->notify()
+        $callable3 = ['event_subscriber_service_id', 'notify'], //Will use ServiceLocator to instantiate service and invoke '$object->notify()' method
         ['another_event_subscriber_service_id', 'notify']
     ]
 ];


### PR DESCRIPTION
When trying to configure an EventBus, the part of registering event subscribers was not totally clear to me. Some questions I had:

- why would I need a ServiceLocator / why is it mandatory?
- why was my 'notify' method invoked statically?

The it struck my that my approach was using:

```
 $callable1 = [My\Class\Name::class, 'notify']
 ```
 
Which is a valid callable, passing the [```is_callable()``` check](https://github.com/SimpleBus/MessageBus/blob/1db0585ca8c2b57d5c1ea17caf4ad2e38250fc73/src/CallableResolver/ServiceLocatorAwareCallableResolver.php#L25), and therefore the method was invoked statically. Eventually I went for the $fqcn approach, which then uses the ServiceLocator to instantiate the classname. 

Not sure whether the suggested approach improves readability, just want to underline that it can be clarified a bit... I also think the ServiceLocator overcomplicates the example, maybe introduce a simpler plain CallableResolver that does not require / use a ServiceLocator? When handing over callables, this seems a more obvious approach opposed to requiring a ServiceLocator that is never used.