### PR TITLE
[RFC] Add SpooledMessageBusMiddleware

### DIFF
--- a/src/Bus/Middleware/SpooledMessageBusMiddleware.php
+++ b/src/Bus/Middleware/SpooledMessageBusMiddleware.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SimpleBus\Message\Bus\Middleware;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class SpooledMessageBusMiddleware implements MessageBusMiddleware
+{
+    private $spool = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle($message, callable $next)
+    {
+        $this->spool[] = function () use ($message, $next) {
+            $next($message);
+        };
+    }
+
+    /**
+     * Flush the spool.
+     */
+    public function flush()
+    {
+        while ($callback = array_shift($this->spool)) {
+            call_user_func($callback);
+        }
+    }
+}


### PR DESCRIPTION
I have a requirement in a Symfony app for all the events to be handled on the `kernel.terminate`/`console.terminate` events. I came up with this middleware and thought I would share.

If this is something you would like to include, I can write tests/docs.