### PR TITLE
allow pass ArrayAccess objects to CallableMap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ phpunit.xml
 .couscous/
 composer.lock
 /build/
+.idea

--- a/src/CallableResolver/CallableMap.php
+++ b/src/CallableResolver/CallableMap.php
@@ -21,7 +21,7 @@ class CallableMap
         $callablesByName,
         CallableResolver $callableResolver
     ) {
-        if(!is_array($callablesByName) && !is_a($callablesByName, \ArrayAccess::class)) {
+        if(!is_array($callablesByName) && !is_a($callablesByName, '\ArrayAccess')) {
             throw new CouldNotResolveCallable("Unexpected callables map - pass array or object implementing ArrayAccess");
         }
         

--- a/src/CallableResolver/CallableMap.php
+++ b/src/CallableResolver/CallableMap.php
@@ -2,6 +2,7 @@
 
 namespace SimpleBus\Message\CallableResolver;
 
+use SimpleBus\Message\CallableResolver\Exception\CouldNotResolveCallable;
 use SimpleBus\Message\CallableResolver\Exception\UndefinedCallable;
 
 class CallableMap
@@ -10,27 +11,32 @@ class CallableMap
      * @var array
      */
     private $callablesByName;
-
+    
     /**
      * @var CallableResolver
      */
     private $callableResolver;
-
+    
     public function __construct(
-        array $callablesByName,
+        $callablesByName,
         CallableResolver $callableResolver
     ) {
-        $this->callablesByName = $callablesByName;
+        if(!is_array($callablesByName) && !is_a($callablesByName, \ArrayAccess::class)) {
+            throw new CouldNotResolveCallable("Unexpected callables map - pass array or object implementing ArrayAccess");
+        }
+        
+        $this->callablesByName  = $callablesByName;
         $this->callableResolver = $callableResolver;
     }
-
+    
     /**
      * @param string $name
+     *
      * @return callable
      */
     public function get($name)
     {
-        if (!array_key_exists($name, $this->callablesByName)) {
+        if(!isset($this->callablesByName[ $name ])) {
             throw new UndefinedCallable(
                 sprintf(
                     'Could not find a callable for name "%s"',
@@ -38,9 +44,9 @@ class CallableMap
                 )
             );
         }
-
-        $callable = $this->callablesByName[$name];
-
+        
+        $callable = $this->callablesByName[ $name ];
+        
         return $this->callableResolver->resolve($callable);
     }
 }

--- a/tests/Handler/CallableMap/CallableMapTest.php
+++ b/tests/Handler/CallableMap/CallableMapTest.php
@@ -1,0 +1,99 @@
+<?php
+namespace SimpleBus\Message\Tests\Handler\CallableMap;
+
+use SimpleBus\Message\CallableResolver\CallableMap;
+use SimpleBus\Message\CallableResolver\Exception\CouldNotResolveCallable;
+use SimpleBus\Message\CallableResolver\ServiceLocatorAwareCallableResolver;
+use SimpleBus\Message\Tests\Handler\CallableMap\Fixtures\DummyCommand;
+use SimpleBus\Message\Tests\Handler\CallableMap\Fixtures\DummyCommandHandler;
+
+class CallableMapTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    function it_accepts_ArrayAccess_interface_as_a_map()
+    {
+        $commandHandlerMap = new CallableMap(
+            $this->sampleArrayAccess(),
+            new ServiceLocatorAwareCallableResolver($this->sampleServiceLocator())
+        );
+        
+        $command_fqcn          = DummyCommand::class;
+        $expected_handler_fqcn = DummyCommandHandler::class;
+        
+        $this->assertEquals($expected_handler_fqcn, $commandHandlerMap->get($command_fqcn)[0]);
+    }
+    
+    /**
+     * @test
+     */
+    function it_accepts_array_as_a_map()
+    {
+        $command_fqcn = DummyCommand::class;
+        $handler_fqcn = DummyCommandHandler::class;
+        
+        $commandHandlerMap = new CallableMap(
+            [
+                $command_fqcn => $handler_fqcn,
+            ],
+            new ServiceLocatorAwareCallableResolver($this->sampleServiceLocator())
+        );
+        
+        $this->assertEquals($handler_fqcn, $commandHandlerMap->get($command_fqcn)[0]);
+    }
+    
+    /**
+     * @test
+     */
+    function it_wont_accept_wrong_types()
+    {
+        $this->setExpectedException(CouldNotResolveCallable::class);
+        
+        new CallableMap(
+            "wrong type",
+            new ServiceLocatorAwareCallableResolver($this->sampleServiceLocator())
+        );
+        
+    }
+    
+    private function sampleArrayAccess()
+    {
+        return (new class() implements \ArrayAccess
+        {
+            public function offsetExists($index)
+            {
+                return class_exists($this->mapCommandToHandler($index), true);
+            }
+            
+            public function offsetGet($index)
+            {
+                return $this->mapCommandToHandler($index);
+            }
+            
+            public function offsetSet($offset, $value)
+            {
+                
+            }
+            
+            public function offsetUnset($offset)
+            {
+                
+            }
+            
+            private function mapCommandToHandler($command_FQCN)
+            {
+                // this is the strategy to map command to handler
+                return $command_FQCN . "Handler";
+            }
+        });
+    }
+    
+    
+    private function sampleServiceLocator()
+    {
+        return function($service_id) {
+            return [$service_id, 'handle'];
+        };
+    }
+}

--- a/tests/Handler/CallableMap/CallableMapTest.php
+++ b/tests/Handler/CallableMap/CallableMapTest.php
@@ -19,8 +19,8 @@ class CallableMapTest extends \PHPUnit_Framework_TestCase
             new ServiceLocatorAwareCallableResolver($this->sampleServiceLocator())
         );
         
-        $command_fqcn          = DummyCommand::class;
-        $expected_handler_fqcn = DummyCommandHandler::class;
+        $command_fqcn          = 'SimpleBus\Message\Tests\Handler\CallableMap\Fixtures\DummyCommand';
+        $expected_handler_fqcn = 'SimpleBus\Message\Tests\Handler\CallableMap\Fixtures\DummyCommandHandler';
         
         $this->assertEquals($expected_handler_fqcn, $commandHandlerMap->get($command_fqcn)[0]);
     }
@@ -30,8 +30,8 @@ class CallableMapTest extends \PHPUnit_Framework_TestCase
      */
     function it_accepts_array_as_a_map()
     {
-        $command_fqcn = DummyCommand::class;
-        $handler_fqcn = DummyCommandHandler::class;
+        $command_fqcn = 'SimpleBus\Message\Tests\Handler\CallableMap\Fixtures\DummyCommand';
+        $handler_fqcn = 'SimpleBus\Message\Tests\Handler\CallableMap\Fixtures\DummyCommandHandler';
         
         $commandHandlerMap = new CallableMap(
             [

--- a/tests/Handler/CallableMap/CallableMapTest.php
+++ b/tests/Handler/CallableMap/CallableMapTest.php
@@ -4,8 +4,7 @@ namespace SimpleBus\Message\Tests\Handler\CallableMap;
 use SimpleBus\Message\CallableResolver\CallableMap;
 use SimpleBus\Message\CallableResolver\Exception\CouldNotResolveCallable;
 use SimpleBus\Message\CallableResolver\ServiceLocatorAwareCallableResolver;
-use SimpleBus\Message\Tests\Handler\CallableMap\Fixtures\DummyCommand;
-use SimpleBus\Message\Tests\Handler\CallableMap\Fixtures\DummyCommandHandler;
+use SimpleBus\Message\Tests\Handler\CallableMap\Fixtures\CommandToHandlerMapper;
 
 class CallableMapTest extends \PHPUnit_Framework_TestCase
 {
@@ -15,7 +14,7 @@ class CallableMapTest extends \PHPUnit_Framework_TestCase
     function it_accepts_ArrayAccess_interface_as_a_map()
     {
         $commandHandlerMap = new CallableMap(
-            $this->sampleArrayAccess(),
+            new CommandToHandlerMapper(),
             new ServiceLocatorAwareCallableResolver($this->sampleServiceLocator())
         );
         
@@ -55,38 +54,6 @@ class CallableMapTest extends \PHPUnit_Framework_TestCase
             new ServiceLocatorAwareCallableResolver($this->sampleServiceLocator())
         );
         
-    }
-    
-    private function sampleArrayAccess()
-    {
-        return (new class() implements \ArrayAccess
-        {
-            public function offsetExists($index)
-            {
-                return class_exists($this->mapCommandToHandler($index), true);
-            }
-            
-            public function offsetGet($index)
-            {
-                return $this->mapCommandToHandler($index);
-            }
-            
-            public function offsetSet($offset, $value)
-            {
-                
-            }
-            
-            public function offsetUnset($offset)
-            {
-                
-            }
-            
-            private function mapCommandToHandler($command_FQCN)
-            {
-                // this is the strategy to map command to handler
-                return $command_FQCN . "Handler";
-            }
-        });
     }
     
     

--- a/tests/Handler/CallableMap/CallableMapTest.php
+++ b/tests/Handler/CallableMap/CallableMapTest.php
@@ -2,7 +2,6 @@
 namespace SimpleBus\Message\Tests\Handler\CallableMap;
 
 use SimpleBus\Message\CallableResolver\CallableMap;
-use SimpleBus\Message\CallableResolver\Exception\CouldNotResolveCallable;
 use SimpleBus\Message\CallableResolver\ServiceLocatorAwareCallableResolver;
 use SimpleBus\Message\Tests\Handler\CallableMap\Fixtures\CommandToHandlerMapper;
 
@@ -47,7 +46,7 @@ class CallableMapTest extends \PHPUnit_Framework_TestCase
      */
     function it_wont_accept_wrong_types()
     {
-        $this->setExpectedException(CouldNotResolveCallable::class);
+        $this->setExpectedException('SimpleBus\Message\CallableResolver\Exception\CouldNotResolveCallable');
         
         new CallableMap(
             "wrong type",

--- a/tests/Handler/CallableMap/Fixtures/CommandToHandlerMapper.php
+++ b/tests/Handler/CallableMap/Fixtures/CommandToHandlerMapper.php
@@ -1,0 +1,32 @@
+<?php
+namespace SimpleBus\Message\Tests\Handler\CallableMap\Fixtures;
+
+class CommandToHandlerMapper implements \ArrayAccess
+{
+    public function offsetExists($index)
+    {
+        return class_exists($this->mapCommandToHandler($index), true);
+    }
+    
+    public function offsetGet($index)
+    {
+        return $this->mapCommandToHandler($index);
+    }
+    
+    public function offsetSet($offset, $value)
+    {
+        
+    }
+    
+    public function offsetUnset($offset)
+    {
+        
+    }
+    
+    private function mapCommandToHandler($command_FQCN)
+    {
+        // this is the strategy to map command to handler
+        return $command_FQCN . "Handler";
+    }
+    
+}

--- a/tests/Handler/CallableMap/Fixtures/DummyCommand.php
+++ b/tests/Handler/CallableMap/Fixtures/DummyCommand.php
@@ -1,0 +1,7 @@
+<?php
+namespace SimpleBus\Message\Tests\Handler\CallableMap\Fixtures;
+
+class DummyCommand
+{
+    
+}

--- a/tests/Handler/CallableMap/Fixtures/DummyCommandHandler.php
+++ b/tests/Handler/CallableMap/Fixtures/DummyCommandHandler.php
@@ -1,0 +1,10 @@
+<?php
+namespace SimpleBus\Message\Tests\Handler\CallableMap\Fixtures;
+
+class DummyCommandHandler
+{
+    public function handle(DummyCommand $command)
+    {
+        
+    }
+}


### PR DESCRIPTION
Hi! 

As discussed in #60 

I have been trying different approaches to solve this problem and it seems to me that "StrategyPattern" is something applicable in this case.

Currently, to make an explicit map I instantiate an object `SimpleBus\Message\CallableResolver\CallableMap` which expects `array` and `SimpleBus\Message\CallableResolver\CallableResolver` as constructor arguments.

I thought it would be great to allow developer to pass `ArrayObject` or `ArrayAccess` instead of simple primitive `array`. 
See:
* https://lornajane.net/posts/2011/arrayaccess-vs-arrayobject 
* http://www.brandonsavage.net/a-closer-look-at-arrayobject/

There is a pickle because currently your function expects `array`:

```
you would have to typehint for ArrayObject instead of Array. There are inconsistencies in the PHP API, which are extremely frustrating but a part of how PHP works.
```

Having this option I would pass this kind of command handler FQCN resolver:

```php
class CommandHandlerMapper extends \ArrayObject
{
    public function offsetExists($index)
    {
        return class_exists($this->mapCommandToHandler($index));
    }
    
    public function offsetGet($index)
    {
        return $this->mapCommandToHandler($index);
    }
    
    private function mapCommandToHandler(string $command_FQCN)
    {
        //This is my strategy to map Command to Handler class name
        return $command_FQCN . "Handler";
    }
}
```

I've prepared a PR for this purpose. 
New test is here: `tests/Handler/CallableMap/CallableMapTest.php`

@matthiasnoback what do you think?