### PR TITLE
Drop support for php 5.4 and 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
 
 before_script:
-  - composer selfupdate
+  - composer self-update
+
+install:
   - composer install --prefer-dist
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.6 || ^7.0",
         "beberlei/assert": "~2.0",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
I'm going to drop support for PHP 5.4 and 5.5 by the end of this month and will release the next major version by then.

All the other pull requests
- https://github.com/SimpleBus/RabbitMQBundleBridge/pull/30
- https://github.com/SimpleBus/DoctrineORMBridge/pull/8
- https://github.com/SimpleBus/DoctrineDBALBridge/pull/2
- https://github.com/SimpleBus/AsynchronousBundle/pull/12
- https://github.com/SimpleBus/Asynchronous/pull/12
- https://github.com/SimpleBus/SymfonyBridge/pull/42
- https://github.com/SimpleBus/SimpleBusBernardBundleBridge/pull/9
- https://github.com/SimpleBus/Serialization/pull/7
- https://github.com/SimpleBus/JMSSerializerBundleBridge/pull/8
- https://github.com/SimpleBus/JMSSerializerBridge/pull/5