### PR TITLE
Symfony 3.3+ compatbilty > Add support for classname based services

### DIFF
--- a/src/CallableResolver/ServiceLocatorAwareCallableResolver.php
+++ b/src/CallableResolver/ServiceLocatorAwareCallableResolver.php
@@ -42,7 +42,15 @@ class ServiceLocatorAwareCallableResolver implements CallableResolver
         }
 
         if (is_array($maybeCallable) && count($maybeCallable) === 2) {
-            list($serviceId, $method) = $maybeCallable;
+            // Symfony 3.3 supports services by classname. This interferes with `is_callable` above
+            // so the SymfonyBridge will now use an array with `serviceId`, `method` keys.
+            if (array_key_exists('serviceId', $maybeCallable)) {
+                $serviceId = $maybeCallable['serviceId'];
+                $method = $maybeCallable['method'];
+            } else {
+                list($serviceId, $method) = $maybeCallable;
+            }
+
             if (is_string($serviceId)) {
                 return $this->resolve([$this->loadService($serviceId), $method]);
             }

--- a/tests/CallableResolver/Fixtures/SubscriberWithCustomNotify.php
+++ b/tests/CallableResolver/Fixtures/SubscriberWithCustomNotify.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SimpleBus\Message\Tests\CallableResolver\Fixtures;
+
+class SubscriberWithCustomNotify
+{
+    public function customNotifyMethod($message)
+    {
+    }
+}

--- a/tests/CallableResolver/ServiceLocatorAwareCallableResolverTest.php
+++ b/tests/CallableResolver/ServiceLocatorAwareCallableResolverTest.php
@@ -5,6 +5,7 @@ namespace SimpleBus\Message\Tests\CallableResolver;
 use SimpleBus\Message\CallableResolver\ServiceLocatorAwareCallableResolver;
 use SimpleBus\Message\Tests\CallableResolver\Fixtures\LegacyHandler;
 use SimpleBus\Message\Tests\CallableResolver\Fixtures\LegacySubscriber;
+use SimpleBus\Message\Tests\CallableResolver\Fixtures\SubscriberWithCustomNotify;
 
 class ServiceLocatorAwareCallableResolverTest extends \PHPUnit\Framework\TestCase
 {
@@ -146,5 +147,21 @@ class ServiceLocatorAwareCallableResolverTest extends \PHPUnit\Framework\TestCas
         $legacySubscriber = new LegacySubscriber();
 
         $this->assertSame([$legacySubscriber, 'notify'], $this->resolver->resolve($legacySubscriber));
+    }
+
+    /**
+     * @test
+     */
+    public function it_supports_class_based_services()
+    {
+        $subscriber = new SubscriberWithCustomNotify();
+
+        $this->services['SimpleBus\Message\Tests\CallableResolver\Fixtures\SubscriberWithCustomNotify'] = $subscriber;
+
+        $callable = [
+            'serviceId' => 'SimpleBus\Message\Tests\CallableResolver\Fixtures\SubscriberWithCustomNotify',
+            'method'    => 'customNotifyMethod',
+        ];
+        $this->assertSame([$subscriber, 'customNotifyMethod'], $this->resolver->resolve($callable));
     }
 }


### PR DESCRIPTION
The `ServiceLocatorAwareCallableResolver` has an `is_callable` check that conflicts with services that are classname based. This commit changes the resolver so that it accepts an array with keys `serviceId` and `method`. This allows the SymfonyBridge to correctly register services that have a classname as serviceId.

Without this change, the subscriber will be called static.